### PR TITLE
fix(brand): header logo srcset + zero-CLS dims

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -35,7 +35,8 @@
 </head>
 <body class="bg-gray-50 text-gray-900">
   <!-- Header -->
-  <header class="container" style="display:flex;align-items:center;gap:.5rem;margin:24px auto;">
+  <img class="brand" src="assets/brand/logo-512.png" srcset="assets/brand/logo-128.png 128w, assets/brand/logo-512.png 512w, assets/brand/logo-1024.png 1024w" sizes="(max-width:640px) 24px, (max-width:1200px) 32px, 40px" width="1024" height="1024">
+<header class="container" style="display:flex;align-items:center;gap:.5rem;margin:24px auto;">
     <img src="./assets/logo/bird-1024.png?v=%BUILD_ID%" srcset="./assets/logo/bird-128.png?v=%BUILD_ID% 128w, ./assets/logo/bird-512.png?v=%BUILD_ID% 512w, ./assets/logo/bird-1024.png?v=%BUILD_ID% 1024w" sizes="(max-width:640px) 24px, (max-width:1200px) 32px, 40px" width="40" height="40" alt="Onbrd" aria-hidden="true" decoding="async" fetchpriority="high" class="brand__mark">
     <div class="brand" style="font-size:20px;letter-spacing:-0.3px;">Onbrd</div>
   </header>
@@ -617,3 +618,4 @@
   <- Add Stripe test card reminder to build: a3a275bce624ca45e712d7b3c75cae64a2431a9c @ 2025-09-24T12:38:29Z -->
 </body>
 </html>
+<!-- build: 2469fe436144c02e5dde2c884b732072e1c72cad @ 2025-09-24T13:16:15+00:00 -->


### PR DESCRIPTION
Wire brand image to site/assets/brand/*.png with srcset/sizes and width/height; adds build stamp.